### PR TITLE
fix: sync SDK_VERSION and CLI versions to 0.3.0

### DIFF
--- a/sdk/javascript/cli/tacp-send.js
+++ b/sdk/javascript/cli/tacp-send.js
@@ -22,7 +22,7 @@ program
   .option('--ttl <seconds>', 'JWT TTL in seconds', '3600')
   .option('--raw', 'Output only base64 message')
   .option('-q, --quiet', 'Suppress warnings')
-  .version('0.2.0');
+  .version('0.3.0');
 
 program.parse();
 

--- a/sdk/javascript/src/version.js
+++ b/sdk/javascript/src/version.js
@@ -1,4 +1,4 @@
 // Schema version for Trusted Agentic Commerce Protocol
 export const SCHEMA_VERSION = '2025-08-27';
-export const SDK_VERSION = '0.2.0';
+export const SDK_VERSION = '0.3.0';
 export const SDK_LANGUAGE = 'JavaScript';

--- a/sdk/python/cli/tacp_send.py
+++ b/sdk/python/cli/tacp_send.py
@@ -70,7 +70,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.2.1",
+        version="%(prog)s 0.3.0",
     )
     return parser
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trusted-agentic-commerce-protocol"
-version = "0.2.1"
+version = "0.3.0"
 description = "Python SDK implementing the Trusted Agentic Commerce Protocol for secure authentication and data encryption between AI agents, merchants and merchant vendors."
 authors = [
     {name = "Forter", email = "support@forter.com"},

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="trusted-agentic-commerce-protocol",
-    version="0.2.1",
+    version="0.3.0",
     author="Forter",
     author_email="support@forter.com",
     description="Python SDK implementing the Trusted Agentic Commerce Protocol for secure authentication and data encryption between AI agents, merchants and merchant vendors.",

--- a/sdk/typescript/cli/tacp-send.ts
+++ b/sdk/typescript/cli/tacp-send.ts
@@ -40,7 +40,7 @@ program
   .option("--ttl <seconds>", "JWT TTL in seconds", "3600")
   .option("--raw", "Output only base64 message")
   .option("-q, --quiet", "Suppress warnings")
-  .version("0.2.0");
+  .version("0.3.0");
 
 program.parse();
 

--- a/sdk/typescript/src/version.ts
+++ b/sdk/typescript/src/version.ts
@@ -1,4 +1,4 @@
 // Schema version for Trusted Agentic Commerce Protocol
 export const SCHEMA_VERSION = "2025-08-27";
-export const SDK_VERSION = "0.2.0";
+export const SDK_VERSION = "0.3.0";
 export const SDK_LANGUAGE = "TypeScript";


### PR DESCRIPTION
## Summary

- `SDK_VERSION` constants in TypeScript (`0.2.0`) and JavaScript (`0.2.0`) were out of sync with their `package.json` (`0.3.0`)
- Python `pyproject.toml` and `setup.py` were at `0.2.1` while `version.py` was already `0.3.0`
- CLI `--version` flags in all three SDKs reported stale versions